### PR TITLE
Ensure Qt tests exit cleanly

### DIFF
--- a/src/jhora/tests/test_ui.py
+++ b/src/jhora/tests/test_ui.py
@@ -18,19 +18,41 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Basic GUI tests for the PyJHora widgets.
+
+This module used to start a Qt application and block waiting for user
+interaction.  When running in headless or CI environments such behaviour
+causes the test suite to hang.  The tests below create the application in
+``offscreen`` mode, instantiate the widget and immediately close everything so
+that the suite finishes promptly.
+"""
+
+import os
 import sys
+import pytest
 from PyQt6.QtWidgets import QApplication
 
-def except_hook(cls, exception, traceback):
-    print('exception called')
-    sys.__excepthook__(cls, exception, traceback)
-sys.excepthook = except_hook
-App = QApplication(sys.argv)
-#from jhora.ui.horo_chart import ChartSimple
-#chart = ChartSimple()
-#chart.show()
-from jhora.ui.horo_chart_tabs import ChartTabbed
-chart = ChartTabbed()
-chart.show()
-sys.exit(App.exec())
-exit()
+
+@pytest.fixture
+def qapp():
+    """Create a QApplication for tests and ensure it is closed afterwards."""
+
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication(sys.argv)
+    yield app
+    # Close all remaining windows and quit the application
+    for widget in list(app.topLevelWidgets()):
+        widget.close()
+    app.quit()
+
+
+def test_chart_tabbed_creation(qapp):
+    """Simply instantiate ``ChartTabbed`` and show/hide it."""
+
+    from jhora.ui.horo_chart_tabs import ChartTabbed
+
+    widget = ChartTabbed()
+    widget.show()
+    qapp.processEvents()
+    assert widget.isVisible()
+    widget.close()


### PR DESCRIPTION
## Summary
- refactor `test_ui.py` to be a proper pytest module
- create a fixture that closes all Qt windows and quits the app
- run the GUI test in offscreen mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fbcbeffdc8327a1714d8c289cfffc